### PR TITLE
Bundle runtime with the application and create a GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: "Create release with published assets"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version"
+        required: true
+      release_notes:
+        description: "Release notes"
+        required: true
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - id: create_release
+        uses: ncipollo/release-action@v1
+        with:
+          body: ${{ inputs.release_notes }}
+          name: "Mass Effect Coalesced Convert"
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+          tag: ${{ format('v{0}', inputs.version) }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      releaseUploadUrl: ${{ steps.create_release.outputs.upload_url }}
+  
+  generate-asset-and-upload:
+    needs: [ create-release ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rid: [ linux-x64, linux-musl-x64, linux-arm, linux-arm64, osx-x64, win-x86, win-x64, win-arm, win-arm64 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore -c Release
+
+      - name: Test
+        run: dotnet test --no-build -c Release --verbosity normal
+
+      - name: Publish App for RID ${{ matrix.rid }}
+        run: dotnet publish ConsoleApp/ConsoleApp.csproj -p:PublishTrimmed=true -p:PublishSingleFile=true -p:EnableCompressionInSingleFile=true -c Release --runtime ${{matrix.rid}} --self-contained
+
+      - name: Upload Windows release asset for RID ${{ matrix.rid }}
+        if: startsWith(matrix.rid, 'win')
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.releaseUploadUrl }}
+          asset_path: ${{ format('ConsoleApp/bin/Release/net6.0/{0}/publish/mecc.exe', matrix.rid) }}
+          asset_name: ${{ format('mecc.exe ({0})', matrix.rid) }}
+          asset_content_type: 'application/octet-stream'
+
+      - name: Upload non-Windows release asset for RID ${{ matrix.rid }}
+        if: startsWith(matrix.rid, 'win') == false
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.releaseUploadUrl }}
+          asset_path: ${{ format('ConsoleApp/bin/Release/net6.0/{0}/publish/mecc', matrix.rid) }}
+          asset_name: ${{ format('mecc ({0})', matrix.rid) }}
+          asset_content_type: 'application/octet-stream'

--- a/CoalescedConvert.sln
+++ b/CoalescedConvert.sln
@@ -12,6 +12,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHubActions", "GitHubActions", "{EF44C70C-02F0-47FC-B2A5-9536D071A73D}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\release.yml = .github\workflows\release.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,5 +37,8 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1CFBA085-7DED-47D6-90BB-AA70F1FEA1FF}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{EF44C70C-02F0-47FC-B2A5-9536D071A73D} = {14049985-886B-4958-9491-CA908EFE10FB}
 	EndGlobalSection
 EndGlobal

--- a/CoalescedConvert.sln
+++ b/CoalescedConvert.sln
@@ -7,6 +7,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoalescedConvert", "Coalesc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp", "ConsoleApp\ConsoleApp.csproj", "{3A52FFBF-1D45-4BDE-9944-3E7ADB5C2CBF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{14049985-886B-4958-9491-CA908EFE10FB}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/CoalescedConvert/CoalescedConvert.csproj
+++ b/CoalescedConvert/CoalescedConvert.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/CoalescedConvert/Properties/launchSettings.json
+++ b/CoalescedConvert/Properties/launchSettings.json
@@ -1,7 +1,0 @@
-{
-  "profiles": {
-    "CoalescedConvert": {
-      "commandName": "Project"
-    }
-  }
-}

--- a/CoalescedConvert/StringTable.cs
+++ b/CoalescedConvert/StringTable.cs
@@ -29,7 +29,7 @@ namespace CoalescedConvert
 
 		public ushort GetId(string str)
 		{
-			return _map.TryGetValue(str.ToLower(), out var id) ? (ushort)id : 0;
+			return _map.TryGetValue(str.ToLower(), out var id) ? (ushort)id : (ushort)0;
 		}
 
 		public string GetString(int id)

--- a/ConsoleApp/ConsoleApp.csproj
+++ b/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>CoalescedConvert</RootNamespace>
     <AssemblyName>mecc</AssemblyName>
     <Company>Chris Mrazek</Company>

--- a/ConsoleApp/ConsoleApp.csproj
+++ b/ConsoleApp/ConsoleApp.csproj
@@ -9,7 +9,7 @@
     <Product>Mass Effect Coalesced Convert</Product>
     <Copyright />
     <PackageId>mecc</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Authors>Chris Mrazek</Authors>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Supported File Formats:
 - Mass Effect 3
 - Mass Effect Legendary Edition (1, 2, and 3)
 
-This app requires .NET 5 to run. If needed you can download it [here](https://dotnet.microsoft.com/download/dotnet/5.0). (Look for .NET Desktop Runtime)
+This app requires .NET 6 to run. If needed you can download it [here](https://dotnet.microsoft.com/download/dotnet/6.0). (Look for .NET Desktop Runtime)
 
 ## Example
 This example will use MassEffect 1 Legendary Edition, downloaded by Origin. Your paths may differ.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,46 @@
 # MECoalescedConvert
 
-A command line utility that can convert a Mass Effect 'Coalesced' file into a regular text INI, or vice-versa. This allows you to make changes to the file without breaking its structure.
+## Introduction
+A command line utility that can convert a Mass Effect "Coalesced" file into a regular text INI, or vice-versa. This allows you to make changes to the file without breaking its structure.
 
 Supported File Formats:
 - Mass Effect 2
 - Mass Effect 3
 - Mass Effect Legendary Edition (1, 2, and 3)
 
-This app requires .NET 6 to run. If needed you can download it [here](https://dotnet.microsoft.com/download/dotnet/6.0). (Look for .NET Desktop Runtime)
+## Downloading
+1. Navigate to the [releases page](https://github.com/cmrazek/MECoalescedConvert/releases).
+2. Find the file matching your current operating system and architecture.
+   - If you're not sure which one you have, it's likely `win-x64`.
+3. Save the file as `mecc.exe` if you are on Windows, or `mecc` if you are on Linux or Mac.
 
 ## Example
-This example will use MassEffect 1 Legendary Edition, downloaded by Origin. Your paths may differ.
+> NOTE: This example will use Mass Effect 1 Legendary Edition, downloaded by Origin. Your paths may differ.
 
-Open a console prompt (cmd / PowerShell) and navigate to the folder where you extracted the app.
+Open a console prompt (cmd / PowerShell) and navigate to the folder where you downloaded the application.
 
-Enter:
-
-`.\mecc "C:\Program Files (x86)\Origin Games\Mass Effect Legendary Edition\Game\ME1\BioGame\CookedPCConsole\Coalesced_INT.bin"`
+Type `.\mecc "C:\Program Files (x86)\Origin Games\Mass Effect Legendary Edition\Game\ME1\BioGame\CookedPCConsole\Coalesced_INT.bin"`
 
 ![Decoding Using PowerShell](https://raw.githubusercontent.com/cmrazek/MECoalescedConvert/master/assets/decode-ps.png)
 
-This will create a new file __Coalesced_INT-export.ini__ in the same folder. Using the text editor of your choice edit this file.
+This will create a new file `Coalesced_INT-export.ini` in the same folder. Edit this file using the text editor of your choice.
 
 ![Editing the File](https://raw.githubusercontent.com/cmrazek/MECoalescedConvert/master/assets/edit-ini.png)
 
-Once you've completed your changes, run __mecc.exe__ again, this time passing in the file name of the text file you just edited.
+Once you've completed your changes, run `mecc` again, this time passing in the file name of the `.ini` text file you just edited.
 
 `.\mecc "C:\Program Files (x86)\Origin Games\Mass Effect Legendary Edition\Game\ME1\BioGame\CookedPCConsole\Coalesced_INT-export.ini"`
 
 ![Encoding Using PowerShell](https://raw.githubusercontent.com/cmrazek/MECoalescedConvert/master/assets/encode-ps.png)
 
-It will save your changes to __Coalesced_INT.bin__.
-The first time this is done, the app will make a backup of the original file (just in case).
+It will save your changes to `Coalesced_INT.bin`. The first time this is done, the app will make a backup of the original file (just in case).
 
 Play the game.
 
 ## ChangeLog
+
+### Version 1.1.0
+- Include the .NET runtime with the application so that there is no longer a dependency to have it installed.
 
 ### Version 1.0.1
 - Changed file name to mecc.exe, because it's easier to type and remember than mecoalc.


### PR DESCRIPTION
* Create a GitHub Action to automatically publish all supported RIDs by .NET as a self-contained deployable.
* Update readme accordingly.
* Update to .NET 6.
* Fix syntax issue
* Bump version to 1.1.0